### PR TITLE
Changed the order of multiplication to avoid overflow for int16 value

### DIFF
--- a/INA219.cpp
+++ b/INA219.cpp
@@ -94,7 +94,7 @@ float INA219::getBusVoltage()
 float INA219::getPower()
 {
   uint16_t value = _readRegister(INA219_POWER);
-  return value * 20 * _current_LSB;
+  return value * _current_LSB * 20;
 }
 
 //  TODO CHECK


### PR DESCRIPTION
Hi there,

i made a small change on the INA219.cpp file to solve the overflow issue on the getPower function by changing the order of multiplication.

Thanks in advance for accepting this change.

Best regards.